### PR TITLE
Remove OutputClass for Intel card as it's automatically detected

### DIFF
--- a/10-nvidia.conf
+++ b/10-nvidia.conf
@@ -6,9 +6,3 @@ Section "OutputClass"
     Option "PrimaryGPU" "yes"
     ModulePath "/usr/lib64/nvidia/xorg"
 EndSection
-
-Section "OutputClass"
-    Identifier "intel"
-    MatchDriver "i915"
-    Driver "modesetting"
-EndSection

--- a/nvidia-driver.spec
+++ b/nvidia-driver.spec
@@ -31,7 +31,7 @@
 
 Name:           nvidia-driver
 Version:        375.26
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        NVIDIA's proprietary display driver for NVIDIA graphic cards
 Epoch:          2
 License:        NVIDIA License
@@ -484,6 +484,10 @@ fi ||:
 %{_libdir}/libnvidia-encode.so
 
 %changelog
+* Fri Dec 23 2016 Jonathan Dieter <jdieter@lesbg.com> - 2:375.26-4
+- Remove OutputClass for Intel card as it's automatically detected when needed
+  and can cause problems when it's not needed.
+
 * Wed Dec 21 2016 Simone Caronni <negativo17@gmail.com> - 2:375.26-3
 - Do not enable nvidia-drm modeset by default yet.
 - Adjust removal of obsolete kernel command line options for RHEL 6.


### PR DESCRIPTION
The OutputClass lines are unneeded for Intel cards as X will automatically choose the modesetting driver instead of the intel driver (even when the intel driver is specified) when using a laptop with dual graphics cards.

The problem with leaving the Intel OutputClass lines in is that they force the use of the modesetting driver, even if on a system without an Nvidia card (or, in my case, a multiseat system where the Intel and Nvidia cards drive two separate seats and run on separate X servers), which causes these systems to fall back to software rendering.

This has been tested on my laptop with dual Nvidia/Intel graphics running F25, negativo17.org multimedia, and libglvnd-enabled mesa, and everything works as expected.

This has also been tested on a school multiseat system with Nvidia, AMD and Intel graphics cards.  The Nvidia card correctly uses the binary driver, while the other three Intel and AMD cards use the libglvnd-enabled mesa drivers.