### PR TITLE
Pre downloaded run files

### DIFF
--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -52,14 +52,20 @@ create_tarball() {
 ARCH=i386
 RUN_FILE=nvidia-${VERSION}-${ARCH}.run
 DIST_FILE=NVIDIA-Linux-x86-${VERSION}.run
-wget -c ${DL_SITE}/Linux-x86/${VERSION}/$DIST_FILE
-mv $DIST_FILE $RUN_FILE
+if [ -f $DIST_FILE ]; then
+    ln -s $DIST_FILE $RUN_FILE
+else
+    wget -c ${DL_SITE}/Linux-x86/${VERSION}/$DIST_FILE -O $RUN_FILE
+fi
 create_tarball
 
 ARCH=x86_64
 RUN_FILE=nvidia-${VERSION}-${ARCH}.run
 DIST_FILE=NVIDIA-Linux-${ARCH}-${VERSION}-no-compat32.run
-wget -c ${DL_SITE}/Linux-${ARCH}/${VERSION}/$DIST_FILE
-mv $DIST_FILE $RUN_FILE
+if [ -f $DIST_FILE ]; then
+    ln -s $DIST_FILE $RUN_FILE
+else
+    wget -c ${DL_SITE}/Linux-${ARCH}/${VERSION}/$DIST_FILE -O $RUN_FILE
+fi
 create_tarball
 

--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -51,13 +51,15 @@ create_tarball() {
 
 ARCH=i386
 RUN_FILE=nvidia-${VERSION}-${ARCH}.run
-wget -c ${DL_SITE}/Linux-x86/${VERSION}/NVIDIA-Linux-x86-${VERSION}.run
-mv NVIDIA-Linux-x86-${VERSION}.run $RUN_FILE
+DIST_FILE=NVIDIA-Linux-x86-${VERSION}.run
+wget -c ${DL_SITE}/Linux-x86/${VERSION}/$DIST_FILE
+mv $DIST_FILE $RUN_FILE
 create_tarball
 
 ARCH=x86_64
 RUN_FILE=nvidia-${VERSION}-${ARCH}.run
-wget -c ${DL_SITE}/Linux-${ARCH}/${VERSION}/NVIDIA-Linux-${ARCH}-${VERSION}-no-compat32.run
-mv NVIDIA-Linux-${ARCH}-${VERSION}-no-compat32.run $RUN_FILE
+DIST_FILE=NVIDIA-Linux-${ARCH}-${VERSION}-no-compat32.run
+wget -c ${DL_SITE}/Linux-${ARCH}/${VERSION}/$DIST_FILE
+mv $DIST_FILE $RUN_FILE
 create_tarball
 

--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -9,7 +9,7 @@ create_tarball() {
     KMOD=nvidia-kmod-${VERSION}-${ARCH}
     DRIVER=nvidia-driver-${VERSION}-${ARCH}
 
-    sh nvidia-${VERSION}-${ARCH}.run --extract-only --target temp
+    sh $RUN_FILE --extract-only --target temp
     mkdir ${KMOD} ${KMOD_MULTI} ${DRIVER}
 
     cd temp
@@ -46,16 +46,18 @@ create_tarball() {
     tar --remove-files -cJf ${KMOD}.tar.xz ${KMOD}
     tar --remove-files -cJf ${DRIVER}.tar.xz ${DRIVER}
 
-    rm -f nvidia-${VERSION}-${ARCH}.run
+    rm -f $RUN_FILE
 }
 
 ARCH=i386
+RUN_FILE=nvidia-${VERSION}-${ARCH}.run
 wget -c ${DL_SITE}/Linux-x86/${VERSION}/NVIDIA-Linux-x86-${VERSION}.run
-mv NVIDIA-Linux-x86-${VERSION}.run nvidia-${VERSION}-${ARCH}.run
+mv NVIDIA-Linux-x86-${VERSION}.run $RUN_FILE
 create_tarball
 
 ARCH=x86_64
+RUN_FILE=nvidia-${VERSION}-${ARCH}.run
 wget -c ${DL_SITE}/Linux-${ARCH}/${VERSION}/NVIDIA-Linux-${ARCH}-${VERSION}-no-compat32.run
-mv NVIDIA-Linux-${ARCH}-${VERSION}-no-compat32.run nvidia-${VERSION}-${ARCH}.run
+mv NVIDIA-Linux-${ARCH}-${VERSION}-no-compat32.run $RUN_FILE
 create_tarball
 

--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -49,23 +49,25 @@ create_tarball() {
     rm -f $RUN_FILE
 }
 
+download_or_link() {
+    if [ -f $DIST_FILE ]; then
+        ln -s $DIST_FILE $RUN_FILE
+    else
+        wget -c ${DL_SITE}/${PLATFORM}/${VERSION}/$DIST_FILE -O $RUN_FILE
+    fi
+}
+
 ARCH=i386
+PLATFORM=Linux-x86
 RUN_FILE=nvidia-${VERSION}-${ARCH}.run
-DIST_FILE=NVIDIA-Linux-x86-${VERSION}.run
-if [ -f $DIST_FILE ]; then
-    ln -s $DIST_FILE $RUN_FILE
-else
-    wget -c ${DL_SITE}/Linux-x86/${VERSION}/$DIST_FILE -O $RUN_FILE
-fi
+DIST_FILE=NVIDIA-${PLATFORM}-${VERSION}.run
+download_or_link
 create_tarball
 
 ARCH=x86_64
+PLATFORM=Linux-${ARCH}
 RUN_FILE=nvidia-${VERSION}-${ARCH}.run
-DIST_FILE=NVIDIA-Linux-${ARCH}-${VERSION}-no-compat32.run
-if [ -f $DIST_FILE ]; then
-    ln -s $DIST_FILE $RUN_FILE
-else
-    wget -c ${DL_SITE}/Linux-${ARCH}/${VERSION}/$DIST_FILE -O $RUN_FILE
-fi
+DIST_FILE=NVIDIA-${PLATFORM}-${VERSION}-no-compat32.run
+download_or_link
 create_tarball
 


### PR DESCRIPTION
This set of patches tidies up nvidia-generate-tarballs.sh a little, and allows the user to provide .run files that they've already downloaded separately.