### PR TITLE
 Update to 396.18, and build i386 driver-libs from x86_64 sources

### DIFF
--- a/nvidia-driver.spec
+++ b/nvidia-driver.spec
@@ -404,13 +404,17 @@ fi || :
 %endif
 # END driver-only
 
-%post libs -p /sbin/ldconfig
+%post libs
+/sbin/ldconfig
 
-%post cuda-libs -p /sbin/ldconfig
+%post cuda-libs
+/sbin/ldconfig
 
-%post NvFBCOpenGL -p /sbin/ldconfig
+%post NvFBCOpenGL
+/sbin/ldconfig
 
-%post NVML -p /sbin/ldconfig
+%post NVML
+/sbin/ldconfig
 
 # START: driver-only
 %if %{with driver}
@@ -434,13 +438,17 @@ fi ||:
 %endif
 # END: driver-only
 
-%postun libs -p /sbin/ldconfig
+%postun libs
+/sbin/ldconfig
 
-%postun cuda-libs -p /sbin/ldconfig
+%postun cuda-libs
+/sbin/ldconfig
 
-%postun NvFBCOpenGL -p /sbin/ldconfig
+%postun NvFBCOpenGL
+/sbin/ldconfig
 
-%postun NVML -p /sbin/ldconfig
+%postun NVML
+/sbin/ldconfig
 
 # START: driver-only
 %if %{with driver}
@@ -556,6 +564,8 @@ fi ||:
 - Split up a new nvidia-driver-headers package, and add it as a dependency
   of nvidia-driver-devel, as it is architecture-independent, and now can only be
   built from the 64-bit driver package.
+- Don't call ldconfig as an interpreter in scriplets. Make it a regular command.
+
 
 * Tue Apr 03 2018 Simone Caronni <negativo17@gmail.com> - 3:390.48-1
 - Update to 390.48.

--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -1,31 +1,53 @@
-#!/bin/sh
+#!/bin/bash
+
 set -e
 
 VERSION=${VERSION:-390.48}
 DL_SITE=${DL_SITE:-http://us.download.nvidia.com/XFree86}
 TEMP_UNPACK=${TEMP_UNPACK:-temp}
+X64_ONLY=${X64_ONLY:-0}
 
 get_run_file() {
-    printf "Downloading installer for ${VERSION} ${ARCH}... "
-    [[ -f $RUN_FILE ]] || wget -c -q ${DL_SITE}/${PLATFORM}/${VERSION}/$RUN_FILE
-    printf "OK\n"
+    printf "Downloading installer for ${VERSION} ${ARCH}... " >&2
+    wget -N -c -q ${DL_SITE}/${PLATFORM}/${VERSION}/$RUN_FILE || return $?
+    printf "OK\n" >&2
 }
 
 extract_run_file() {
-    sh ${RUN_FILE} --extract-only --target ${TEMP_UNPACK}
+    local dest_dir="$1" src_file="$PWD/$RUN_FILE"
+    local fname="${src_file##*/}"
+    local dest_subdir="${fname%.run}"
+    dest_dir="$dest_dir/$dest_subdir"
+
+    if [ -e "$dest_dir" ]; then
+        rm -rf "$dest_dir"
+    fi
+
+    sh "$src_file" --extract-only --target "$dest_dir" >&2 || return $?
+    echo "$dest_dir"
 }
 
-create_tarball() {
-    printf "Creating tarballs for ${VERSION} ${ARCH}... "
+create_kmod_tarball() {
+    local src_dir="$1"
+    local kmod_name="nvidia-kmod-${VERSION}-${ARCH}"
+    printf "Creating kernel module tarball for ${VERSION} ${ARCH}... " >&2
 
-    KMOD=nvidia-kmod-${VERSION}-${ARCH}
-    DRIVER=nvidia-driver-${VERSION}-${ARCH}
-    mkdir ${KMOD} ${DRIVER}
+    tar -cJv -f "${kmod_name}.tar.xz.tmp" \
+        --transform "s!^!${kmod_name}/!S" \
+        --show-transformed-names \
+        -C "$src_dir" kernel || return $?
+    mv "${kmod_name}.tar.xz"{.tmp,}
+}
 
-    cd ${TEMP_UNPACK}
+create_driver_tarball() {
+    local src_dir="$1" prefix="$2"
+    local driver_name="nvidia-driver-${VERSION}-${ARCH}"
 
-    # Compiled from source
-    rm -f \
+    printf "Creating driver tarball for ${VERSION} ${ARCH}... " >&2
+
+    set -f
+    local -a exclude=(
+        # Compiled from source
         nvidia-xconfig* \
         nvidia-persistenced* \
         nvidia-modprobe* \
@@ -33,42 +55,56 @@ create_tarball() {
         libGLESv1_CM.so.* libGLESv2.so.* libGL.la libGLdispatch.so.* libOpenGL.so.* libGLX.so.* libGL.so.1* libEGL.so.1* \
         libnvidia-egl-wayland.so.* \
         libOpenCL.so.1*
+        # Non GLVND libraries
+        libGL.so.${VERSION} libEGL.so.${VERSION}
+        # Useless with packages
+        nvidia-installer* .manifest make* mk* tls_test*
+        # useless on modern distributions
+        libnvidia-wfb*
+        # kmod has its own tarball
+        kernel
+        # 32-bit on 64-bit package is handled separately
+        32
+    )
+    set +f
 
-    # Non GLVND libraries
-    rm -f libGL.so.${VERSION} libEGL.so.${VERSION}
-
-    # Useless with packages
-    rm -f nvidia-installer* .manifest make* mk* tls_test*
-
-    # useless on modern distributions
-    rm -f libnvidia-wfb*
-
-    # Use correct tls implementation
-    mv -f tls/libnvidia-tls.so* .
-    rm -fr tls
-
-    mv kernel ../${KMOD}/
-    mv * ../${DRIVER}/
-
-    cd ..
-    rm -fr ${TEMP_UNPACK}
-
-    tar --remove-files -cJf ${KMOD}.tar.xz ${KMOD}
-    tar --remove-files -cJf ${DRIVER}.tar.xz ${DRIVER}
-
-    printf "OK\n"
+    tar -cJv -f "${driver_name}.tar.xz.tmp" \
+        --anchored $(printf -- '--exclude=./%s ' "${exclude[@]}") \
+        --transform 's!^\./tls/!./!S' \
+        --transform "s!^\\./!${driver_name}/!S" \
+        --show-transformed-names \
+        -C "$src_dir/$prefix/" . || return $?
+    mv "${driver_name}.tar.xz"{.tmp,}
 }
 
-ARCH=i386
-PLATFORM=Linux-x86
-RUN_FILE=NVIDIA-${PLATFORM}-${VERSION}.run
-get_run_file
-extract_run_file
-create_tarball
+if [ "$X64_ONLY" -ne 1 ]; then
+    ARCH=i386
+    PLATFORM=Linux-x86
+    RUN_FILE=NVIDIA-${PLATFORM}-${VERSION}.run
+    if get_run_file; then
+        src_dir=$(extract_run_file "$TEMP_UNPACK")
+        create_kmod_tarball "$src_dir"
+        create_driver_tarball "$src_dir"
+    else
+        echo "WARN: Failed to download 32-bit driver package" >&2
+        X64_ONLY=1
+    fi
+fi
 
 ARCH=x86_64
 PLATFORM=Linux-${ARCH}
-RUN_FILE=NVIDIA-${PLATFORM}-${VERSION}-no-compat32.run
+if [ "$X64_ONLY" -eq 1 ]; then
+    RUN_FILE=NVIDIA-${PLATFORM}-${VERSION}.run
+else
+    RUN_FILE=NVIDIA-${PLATFORM}-${VERSION}-no-compat32.run
+fi
+
 get_run_file
-extract_run_file
-create_tarball
+src_dir=$(extract_run_file "$TEMP_UNPACK")
+create_kmod_tarball "$src_dir"
+create_driver_tarball "$src_dir"
+
+# Generate the 32-bit libs tarballs from the 64-bit package
+if [ "$X64_ONLY" -eq 1 ]; then
+    ARCH=i386 PLATFORM=Linux-${ARCH} create_driver_tarball "$src_dir" 32
+fi


### PR DESCRIPTION
Now that NVIDIA has decided not to support 32-bit systems any further,
the i386 driver libs must be pulled from the 64-bit driver package.

Since I really wanted to build the 396.18 drivers for the Vulkan changes,
I had to make some changes to have it build successfully. Hopefully my
approach is acceptable to you (I made it possible to conditionally disable
 everything but library packages).

The commit messages explain the changes in more detail.