### PR TITLE
Remove python2 builddep on non-fedora

### DIFF
--- a/nvidia-driver.spec
+++ b/nvidia-driver.spec
@@ -29,7 +29,11 @@ Source99:       nvidia-generate-tarballs.sh
 
 %ifarch x86_64
 
+# We only generate appstream metadata from the
+# readme on Fedora
+%if 0%{?fedora}
 BuildRequires:  python2
+%endif
 
 %if 0%{?fedora} || 0%{?rhel} >= 8
 # AppStream metadata generation


### PR DESCRIPTION
We only use the parse-readme.py script on Fedora, so we don't need
python2 on other systems.

And just as I was writing this, I was wondering - is this really what's wanted or should the spec file instead generate the appstream metadata on rhel8 as well? Since the `libappstream-glib` dependency is for Fedora and RHEL 8 as well and AFAICS only exists for `appstream-util`.