### PR TITLE
chore: do various cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.tar.xz
 *.run
+nvidia-driver-*/
+nvidia-kmod-*/
+nvidia-kmod-common-*/

--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -30,7 +30,6 @@ run_file_extract() {
 }
 
 cleanup_folder() {
-
     printf "Cleaning up binaries... "
 
     cd ${TEMP_UNPACK}
@@ -69,7 +68,6 @@ cleanup_folder() {
 }
 
 create_tarball() {
-
     KMOD=nvidia-kmod-${VERSION}-${ARCH}
     KMOD_COMMON=nvidia-kmod-common-${VERSION}
     USR_64=nvidia-driver-${VERSION}-${ARCH}
@@ -79,27 +77,19 @@ create_tarball() {
     mv ${TEMP_UNPACK}/firmware ${TEMP_UNPACK}/nvidia-bug-report.sh ${KMOD_COMMON}/
 
     if [ "$ARCH" == x86_64 ]; then
-
         USR_32=nvidia-driver-${VERSION}-i386
-
         mkdir ${USR_32} 
         mv ${TEMP_UNPACK}/32/* ${USR_32}/
         rm -fr ${TEMP_UNPACK}/32
-
     fi
 
     mv ${TEMP_UNPACK}/* ${USR_64}/
-
     rm -fr ${TEMP_UNPACK}
 
     for tarball in ${KMOD} ${KMOD_COMMON} ${USR_64} ${USR_32}; do
-
         printf "Creating tarball $tarball... "
-
         XZ_OPT='-T0' tar --remove-files -cJf $tarball.tar.xz $tarball
-
         printf "OK\n"
-
     done
 }
 

--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -2,6 +2,7 @@
 set -e
 
 set_vars() {
+   echo "Building for ${ARCH} using version ${VERSION}"
    export VERSION=${VERSION:-580.95.05}
    export TEMP_UNPACK=${ARCH}
    export PLATFORM=Linux-${ARCH}
@@ -102,16 +103,12 @@ create_tarball() {
     done
 }
 
-ARCH=aarch64
-set_vars
-run_file_get
-run_file_extract
-cleanup_folder
-create_tarball
+ARCHES=${ARCHES:-"x86_64 aarch64"}
 
-ARCH=x86_64
-set_vars
-run_file_get
-run_file_extract
-cleanup_folder
-create_tarball
+for ARCH in $ARCHES; do
+    set_vars
+    run_file_get
+    run_file_extract
+    cleanup_folder
+    create_tarball
+done

--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 set_vars() {

--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -69,13 +69,14 @@ create_tarball() {
     KMOD=nvidia-kmod-${VERSION}-${ARCH}
     KMOD_COMMON=nvidia-kmod-common-${VERSION}
     USR_64=nvidia-driver-${VERSION}-${ARCH}
+    USR_32=nvidia-driver-${VERSION}-i386
 
+    rm -rf ${KMOD} ${KMOD_COMMON} ${USR_64} ${USR_32}
     mkdir ${KMOD} ${KMOD_COMMON} ${USR_64}
     mv ${TEMP_UNPACK}/kernel* ${KMOD}/
     mv ${TEMP_UNPACK}/firmware ${TEMP_UNPACK}/nvidia-bug-report.sh ${KMOD_COMMON}/
 
     if [ "$ARCH" == x86_64 ]; then
-        USR_32=nvidia-driver-${VERSION}-i386
         mkdir ${USR_32} 
         mv ${TEMP_UNPACK}/32/* ${USR_32}/
         rm -fr ${TEMP_UNPACK}/32

--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -31,8 +31,7 @@ run_file_extract() {
 
 cleanup_folder() {
     printf "Cleaning up binaries... "
-
-    cd ${TEMP_UNPACK}
+    pushd ${TEMP_UNPACK}
 
     # Stuff not needed for packages:
     #   - Compiled from source
@@ -62,8 +61,7 @@ cleanup_folder() {
         cp -f *.json* 32/
     fi
 
-    cd ..
-
+    popd
     printf "OK\n"
 }
 


### PR DESCRIPTION
Shapes up the generate file by updating gitignore, making it work after ctrl+C, and allowing to skip arches.