### PR TITLE
Fix wget, allow building nvidia-driver with arch-specific sources

### DIFF
--- a/nvidia-driver.spec
+++ b/nvidia-driver.spec
@@ -17,9 +17,15 @@ License:        NVIDIA License
 URL:            http://www.nvidia.com/object/unix.html
 ExclusiveArch:  %{ix86} x86_64 aarch64
 
+%ifarch %{ix86}
 Source0:        %{name}-%{version}-i386.tar.xz
+%endif
+%ifarch x86_64
 Source1:        %{name}-%{version}-x86_64.tar.xz
+%endif
+%ifarch aarch64
 Source2:        %{name}-%{version}-aarch64.tar.xz
+%endif
 Source8:        70-nvidia-driver.preset
 Source9:        70-nvidia-driver-cuda.preset
 Source10:       10-nvidia.conf

--- a/nvidia-generate-tarballs.sh
+++ b/nvidia-generate-tarballs.sh
@@ -13,9 +13,9 @@ run_file_get() {
     printf "Downloading installer ${RUN_FILE}... "
     if [[ ! -f $RUN_FILE ]]; then
         # This is getting ridiculous:
-        if wget -S --spider https://us.download.nvidia.com/XFree86/${PLATFORM}/${VERSION}/$RUN_FILE | grep -q 'HTTP response 200'; then
+        if wget -S --spider https://us.download.nvidia.com/XFree86/${PLATFORM}/${VERSION}/$RUN_FILE; then
             wget -c -q https://us.download.nvidia.com/XFree86/${PLATFORM}/${VERSION}/$RUN_FILE
-        elif wget -S --spider https://us.download.nvidia.com/XFree86/${ARCH}/${VERSION}/$RUN_FILE | grep -q 'HTTP response 200'; then
+        elif wget -S --spider https://us.download.nvidia.com/XFree86/${ARCH}/${VERSION}/$RUN_FILE; then
             wget -c -q https://us.download.nvidia.com/XFree86/${ARCH}/${VERSION}/$RUN_FILE
         else
             wget -c -q https://us.download.nvidia.com/tesla/${VERSION}/$RUN_FILE


### PR DESCRIPTION
Nvidia updated their mirrors to HTTP/1.1, causing the grep for wget to fail. grep is not needed because we get an error response so remove it alltogether.

Then, add conditionals to nvidia-driver for arch specific sources, to allow building only x86 while aarch is missing from repos.